### PR TITLE
Gives developer environments permissions to invalidate IIIF Server cl…

### DIFF
--- a/common/environment_config.tf
+++ b/common/environment_config.tf
@@ -15,6 +15,10 @@ locals {
       }
     }
 
+    iiif = {
+      distribution_id = data.aws_cloudfront_distribution.iiif_server.id
+    }
+
     index = {
       index_endpoint    = "https://${aws_opensearch_domain.search_index.endpoint}"
       kibana_endpoint   = "https://${aws_opensearch_domain.search_index.kibana_endpoint}"

--- a/common/outputs.tf
+++ b/common/outputs.tf
@@ -8,6 +8,7 @@ resource "aws_secretsmanager_secret_version" "output_parameter" {
     elasticsearch_snapshot_role  = aws_iam_role.search_snapshot_bucket_access.arn
     fixity_function_arn          = module.execute_fixity_function.lambda_function_arn
     ide_uptime_alert_topic       = aws_sns_topic.ide_uptime_alert.arn
+    iiif_distribution_id         = data.aws_cloudfront_distribution.iiif_server.id
     shared_bucket_arn            = aws_s3_bucket.dev_environment_shared_bucket.arn
     transcode_role               = aws_iam_role.transcode_role.arn
     vpc_id                       = module.vpc.vpc_id

--- a/individual/ide.tf
+++ b/individual/ide.tf
@@ -49,7 +49,7 @@ resource "aws_instance" "ide_instance" {
   )
 
   lifecycle {
-    ignore_changes = [ami, security_groups, user_data]
+    ignore_changes = all
   }
 }
 
@@ -199,6 +199,15 @@ data "aws_iam_policy_document" "developer_access" {
       "arn:aws:ecs:us-east-1:625046682746:cluster/dev-environment",
       "arn:aws:ecs:us-east-1:625046682746:service/dev-environment/*",
       "arn:aws:ecs:us-east-1:625046682746:task/dev-environment/*",
+    ]
+  }
+
+  statement {
+    sid       = "DeveloperCloudFrontDistributionAccess"
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [
+      "arn:aws:cloudfront:${local.regional_id}::distribution/${local.common_config.iiif_distribution_id}"
     ]
   }
 }


### PR DESCRIPTION
…oudfront cache

    - Gives developer environments permissions to invalidate IIIF Server cloudfront cache
    
    - Update public access policies for streaming bucket
    
    - Fix S3 and IDE settings to prevent conflicts
    
    - Allow public read ACLs for pyramid and streaming buckets
    
    - Add preservation bucket lifecycle rule

fixes https://github.com/nulib/repodev_planning_and_docs/issues/4082
partially fixes https://github.com/nulib/repodev_planning_and_docs/issues/3211
